### PR TITLE
feat: adiciona documentação da API com Swagger UI

### DIFF
--- a/caronas/pom.xml
+++ b/caronas/pom.xml
@@ -38,7 +38,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version> </dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/caronas/src/main/java/com/beebee/caronas/config/OpenApiConfig.java
+++ b/caronas/src/main/java/com/beebee/caronas/config/OpenApiConfig.java
@@ -1,0 +1,17 @@
+package com.beebee.caronas.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(
+        title = "API de Caronas BeeBee",
+        version = "1.0",
+        description = "Documentação da API para o sistema de Caronas do BeeBee."
+    )
+)
+public class OpenApiConfig {
+
+}

--- a/caronas/src/main/java/com/beebee/caronas/exceptions/GlobalExceptionHandler.java
+++ b/caronas/src/main/java/com/beebee/caronas/exceptions/GlobalExceptionHandler.java
@@ -7,9 +7,12 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import io.swagger.v3.oas.annotations.Hidden;
+
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
+@Hidden
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
**Problema Resolvido:**

Este Pull Request soluciona o erro 500 que ocorria ao tentar acessar a documentação do Swagger UI na rota `/v3/api-docs`. O erro específico era um `java.lang.NoSuchMethodError` relacionado à classe interna `ControllerAdviceBean` do Spring Framework.

**Causa Raiz:**

A causa do problema era uma incompatibilidade sutil entre a versão do Spring Boot 3.5.0 do projeto e como o Springdoc OpenAPI tentava inspecionar e carregar o `@RestControllerAdvice` (`GlobalExceptionHandler.java`) para gerar a documentação da API. Ele tentava utilizar um construtor de método da classe `ControllerAdviceBean` que não existe mais nas versões mais recentes do Spring Framework (Spring 6.x), causando o erro em tempo de execução.

**Solução Implementada:**

1.  **Integração do Springdoc OpenAPI:** Adicionada a dependência `org.springdoc:springdoc-openapi-starter-webmvc-ui` no `pom.xml` para habilitar a documentação Swagger UI.
2.  **Configuração de Metadados:** Criado o arquivo `OpenApiConfig.java` para fornecer informações básicas da API, como título e versão, seguindo as boas práticas.
3.  **Ajuste de Logs (Remoção de DEBUG):** As configurações de `logging.level.org.springdoc`, `logging.level.org.springframework.web`, e `logging.level.org.hibernate` foram removidas/ajustadas em `application.properties` para evitar logs excessivos em produção.
4.  **Resolução do Conflito do `GlobalExceptionHandler`:** A anotação `@Hidden` foi adicionada à classe `GlobalExceptionHandler.java`. Isso instrui o Springdoc OpenAPI a ignorar esta classe especificamente durante a geração da documentação, eliminando o `NoSuchMethodError` e permitindo que a classe `GlobalExceptionHandler` continue funcionando normalmente para o tratamento de exceções da aplicação.

**Benefícios:**

* A API agora possui documentação interativa acessível via Swagger UI.
* O tratamento global de exceções da aplicação permanece funcional.
* A base de código está mais robusta e pronta para novas features.